### PR TITLE
Add Tests & sample responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 octopus-serverspec-extensions-*.gem
 vendor/
 /.idea/
+publish.ps1

--- a/lib/octopus_serverspec_extensions/type/octopus_deploy_environment.rb
+++ b/lib/octopus_serverspec_extensions/type/octopus_deploy_environment.rb
@@ -49,6 +49,7 @@ module Serverspec::Type
       environment = body['Items'].first unless body.nil?
     rescue => e
       puts "Unable to connect to #{url}: #{e}"
+      raise
     end
 
     environment

--- a/lib/octopus_serverspec_extensions/type/octopus_deploy_environment.rb
+++ b/lib/octopus_serverspec_extensions/type/octopus_deploy_environment.rb
@@ -16,19 +16,20 @@ module Serverspec::Type
       @apiKey = apiKey
 
       if (serverUrl.nil?)
-        puts "'serverUrl' was not provided. Unable to connect to Octopus server to validate configuration."
-        return
+        raise "'serverUrl' was not provided. Unable to connect to Octopus server to validate configuration."
       end
       if (apiKey.nil?)
-        puts "'apiKey' was not provided. Unable to connect to Octopus server to validate configuration."
-        return
+        raise "'apiKey' was not provided. Unable to connect to Octopus server to validate configuration."
+      end
+      if (environment_name.nil?)
+        raise "'environment_name' was not provided. Unable to connect to Octopus server to validate configuration."
       end
 
       @environment = get_environment_via_api(serverUrl, apiKey, environment_name)
     end
 
     def exists?
-      !@environment.nil?
+      (!@environment.nil?) && (@environment != [])
     end
   end
 

--- a/lib/octopus_serverspec_extensions/type/octopus_deploy_environment.rb
+++ b/lib/octopus_serverspec_extensions/type/octopus_deploy_environment.rb
@@ -48,8 +48,7 @@ module Serverspec::Type
       body = JSON.parse(resp.body)
       environment = body['Items'].first unless body.nil?
     rescue => e
-      puts "Unable to connect to #{url}: #{e}"
-      raise
+      raise "Unable to connect to #{url}: #{e}"
     end
 
     environment

--- a/lib/octopus_serverspec_extensions/type/octopus_deploy_worker_pool.rb
+++ b/lib/octopus_serverspec_extensions/type/octopus_deploy_worker_pool.rb
@@ -16,19 +16,20 @@ module Serverspec::Type
       @apiKey = apiKey
 
       if (serverUrl.nil?)
-        puts "'serverUrl' was not provided. Unable to connect to Octopus server to validate configuration."
-        return
+        raise "'serverUrl' was not provided. Unable to connect to Octopus server to validate configuration."
       end
       if (apiKey.nil?)
-        puts "'apiKey' was not provided. Unable to connect to Octopus server to validate configuration."
-        return
+        raise "'apiKey' was not provided. Unable to connect to Octopus server to validate configuration."
+      end
+      if (worker_pool_name.nil?)
+        raise "'worker_pool_name' was not provided. Unable to connect to Octopus server to validate configuration."
       end
 
       @worker_pool = get_worker_pool_via_api(serverUrl, apiKey, worker_pool_name)
     end
 
     def exists?
-      !@worker_pool.nil?
+      (!@worker_pool.nil?) && (@worker_pool != [])
     end
   end
 
@@ -41,6 +42,7 @@ module Serverspec::Type
   def get_worker_pool_via_api(serverUrl, apiKey, worker_pool_name)
     worker_pool = nil
     url = "#{serverUrl}/api/workerpools/all?api-key=#{apiKey}"
+    puts url
 
     begin
       resp = Net::HTTP.get_response(URI.parse(url))
@@ -48,6 +50,7 @@ module Serverspec::Type
       worker_pool = body.select {|i| i['Name'] == worker_pool_name } unless body.nil?
     rescue => e
       puts "Unable to connect to #{url}: #{e}"
+      raise
     end
 
     worker_pool

--- a/lib/octopus_serverspec_extensions/type/octopus_deploy_worker_pool.rb
+++ b/lib/octopus_serverspec_extensions/type/octopus_deploy_worker_pool.rb
@@ -42,7 +42,6 @@ module Serverspec::Type
   def get_worker_pool_via_api(serverUrl, apiKey, worker_pool_name)
     worker_pool = nil
     url = "#{serverUrl}/api/workerpools/all?api-key=#{apiKey}"
-    puts url
 
     begin
       resp = Net::HTTP.get_response(URI.parse(url))

--- a/lib/octopus_serverspec_extensions/type/octopus_deploy_worker_pool.rb
+++ b/lib/octopus_serverspec_extensions/type/octopus_deploy_worker_pool.rb
@@ -48,8 +48,7 @@ module Serverspec::Type
       body = JSON.parse(resp.body)
       worker_pool = body.select {|i| i['Name'] == worker_pool_name } unless body.nil?
     rescue => e
-      puts "Unable to connect to #{url}: #{e}"
-      raise
+      raise "Unable to connect to #{url}: #{e}"
     end
 
     worker_pool

--- a/lib/octopus_serverspec_extensions/version.rb
+++ b/lib/octopus_serverspec_extensions/version.rb
@@ -1,3 +1,3 @@
 module OctopusServerSpecExtensions
-  VERSION = "0.14.0"
+  VERSION = "0.15.0"
 end

--- a/octopus-serverspec-extensions.gemspec
+++ b/octopus-serverspec-extensions.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-teamcity", "~> 0.0.1"
+  spec.add_development_dependency "webmock", "~> 3.5.1"
 
 end

--- a/octopus-serverspec-extensions.gemspec
+++ b/octopus-serverspec-extensions.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "serverspec", "~> 2"
   spec.add_dependency "specinfra", "~> 2"
   spec.add_dependency 'rspec', '~> 3.0'
-  spec.add_dependency 'json', '~> 2.1'
+  spec.add_dependency 'json', '~> 2.2'
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/octopus/serverspec/json/envfound.json
+++ b/spec/octopus/serverspec/json/envfound.json
@@ -1,0 +1,30 @@
+{
+  "ItemType": "Environment",
+  "TotalResults": 1,
+  "ItemsPerPage": 10,
+  "NumberOfPages": 1,
+  "LastPageNumber": 0,
+  "Items": [
+    {
+      "Id": "Environments-1",
+      "Name": "The-Env",
+      "Description": "",
+      "SortOrder": 0,
+      "UseGuidedFailure": false,
+      "AllowDynamicInfrastructure": false,
+      "SpaceId": "Spaces-1",
+      "Links": {
+        "Self": "/api/Spaces-1/environments/Environments-1",
+        "Machines": "/api/Spaces-1/environments/Environments-1/machines{?skip,take,partialName,roles,isDisabled,healthStatuses,commStyles,tenantIds,tenantTags}",
+        "SinglyScopedVariableDetails": "/api/Spaces-1/environments/Environments-1/singlyScopedVariableDetails"
+      }
+    }
+  ],
+  "Links": {
+    "Self": "/api/Spaces-1/environments",
+    "Template": "/api/Spaces-1/environments{?skip,ids,take,partialName}",
+    "Page.All": "/api/Spaces-1/environments?skip=0&take=2147483647",
+    "Page.Current": "/api/Spaces-1/environments?skip=0&take=10",
+    "Page.Last": "/api/Spaces-1/environments?skip=0&take=10"
+  }
+}

--- a/spec/octopus/serverspec/json/envnotfound.json
+++ b/spec/octopus/serverspec/json/envnotfound.json
@@ -1,0 +1,15 @@
+{
+    "ItemType": "Environment",
+    "TotalResults": 0,
+    "ItemsPerPage": 10,
+    "NumberOfPages": 1,
+    "LastPageNumber": 0,
+    "Items": [],
+    "Links": {
+      "Self": "/api/Spaces-1/environments",
+      "Template": "/api/Spaces-1/environments{?skip,ids,take,partialName}",
+      "Page.All": "/api/Spaces-1/environments?skip=0&take=2147483647",
+      "Page.Current": "/api/Spaces-1/environments?skip=0&take=10",
+      "Page.Last": "/api/Spaces-1/environments?skip=0&take=10"
+    }
+  }

--- a/spec/octopus/serverspec/json/workerpoolsall.json
+++ b/spec/octopus/serverspec/json/workerpoolsall.json
@@ -1,0 +1,38 @@
+[
+  {
+    "Id": "WorkerPools-1",
+    "Name": "Default Worker Pool",
+    "Description": "Default pool of workers",
+    "IsDefault": true,
+    "SortOrder": 0,
+    "SpaceId": "Spaces-1",
+    "Links": {
+      "Self": "/api/Spaces-1/workerpools/WorkerPools-1",
+      "Workers": "/api/Spaces-1/workerpools/WorkerPools-1/workers{?skip,take,partialName,isDisabled,healthStatuses,commStyles}"
+    }
+  },
+  {
+    "Id": "WorkerPools-2",
+    "Name": "Second Worker Pool",
+    "Description": "I was the second pool added to this server",
+    "IsDefault": false,
+    "SortOrder": 1,
+    "SpaceId": "Spaces-1",
+    "Links": {
+      "Self": "/api/Spaces-1/workerpools/WorkerPools-2",
+      "Workers": "/api/Spaces-1/workerpools/WorkerPools-2/workers{?skip,take,partialName,isDisabled,healthStatuses,commStyles}"
+    }
+  },
+  {
+    "Id": "WorkerPools-3",
+    "Name": "Third Worker Pool",
+    "Description": "Of all the pools, I got the bronze",
+    "IsDefault": false,
+    "SortOrder": 2,
+    "SpaceId": "Spaces-1",
+    "Links": {
+      "Self": "/api/Spaces-1/workerpools/WorkerPools-3",
+      "Workers": "/api/Spaces-1/workerpools/WorkerPools-3/workers{?skip,take,partialName,isDisabled,healthStatuses,commStyles}"
+    }
+  }
+]

--- a/spec/octopus/serverspec/type/octopus_deploy_environment_spec.rb
+++ b/spec/octopus/serverspec/type/octopus_deploy_environment_spec.rb
@@ -20,30 +20,28 @@ describe OctopusDeployEnvironment do
             to raise_error(/environment_name/)
     end
 
-    examplejsonpath = 'spec/octopus/serverspec/json/envfound.json'
-    examplejson = File.open(examplejsonpath)
+    example_environment_found_response = File.open('spec/octopus/serverspec/json/envfound.json')
 
     it "handles environment found" do
         stub_request(:get, "https://octopus.example.com/api/environments?name=The-Env&api-key=API-1234567890").
-            to_return(status: 200, body: examplejson, headers: {})
+            to_return(status: 200, body: example_environment_found_response, headers: {})
         ef = OctopusDeployEnvironment.new("https://octopus.example.com", "API-1234567890", "The-Env")
         expect(ef.exists?).to be true
     end
 
-    examplejsonpath2 = 'spec/octopus/serverspec/json/envnotfound.json'
-    examplejson2 = File.open(examplejsonpath2) # you get an IOError if you reuse the earlier File.open()
+    example_environment_note_found_response = File.open('spec/octopus/serverspec/json/envnotfound.json') # you get an IOError if you reuse the earlier File.open()
 
     it "handles environment not found" do
         stub_request(:get, "https://octopus2.example.com/api/environments?name=Not-an-Env&api-key=API-0987654321").
-            to_return(status: 200, body: examplejson2, headers: {})
+            to_return(status: 200, body: example_environment_note_found_response, headers: {})
         enf = OctopusDeployEnvironment.new("https://octopus2.example.com", "API-0987654321", "Not-an-Env")
         expect(enf.exists?).to be false
     end
 
     it "doesn't crash badly if handed a bad URL" do
-        stub_request(:get, "https://octopus.example.com/api/environments?name=The-Env&api-key=API-1234567890").to_raise(StandardError)
+        stub_request(:get, "https://nonexistentdomain.com/api/environments?name=The-Env&api-key=API-1234567890").to_raise(SocketError)
 
-        expect { OctopusDeployEnvironment.new("https://octopus.example.com", "API-1234567890", "The-Env") }.to raise_error(StandardError)
+        expect { OctopusDeployEnvironment.new("https://nonexistentdomain.com", "API-1234567890", "The-Env") }.to raise_error(StandardError)
     end
 
 end

--- a/spec/octopus/serverspec/type/octopus_deploy_environment_spec.rb
+++ b/spec/octopus/serverspec/type/octopus_deploy_environment_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'webmock/rspec'
+
+describe OctopusDeployEnvironment do
+
+    let(:runner) { double ("runner")}
+
+    it "throws if `serverUrl` not supplied" do
+        expect { OctopusDeployEnvironment.new(nil, "someapikey", "my new environment") }.
+            to raise_error(/serverUrl/)
+    end
+
+    it "throws if `apiKey` not supplied" do
+        expect { OctopusDeployEnvironment.new("https://someserver.com", nil, "my new environment") }.
+            to raise_error(/apiKey/)
+    end
+
+    it "throws if `environmentname` not supplied" do
+        expect { OctopusDeployEnvironment.new("https://someserver.com", "API-kllkjhasdkljhasdfkjsafd", nil) }.
+            to raise_error(/environment_name/)
+    end
+
+    examplejsonpath = 'spec/octopus/serverspec/json/envfound.json'
+    examplejson = File.open(examplejsonpath)
+
+    it "handles environment found" do
+        stub_request(:get, "https://octopus.example.com/api/environments?api-key=API-1234567890&name=The-Env").
+            to_return(status: 200, body: examplejson, headers: {})
+        ef = OctopusDeployEnvironment.new("https://octopus.example.com", "API-1234567890", "The-Env")
+        expect(ef.exists?).to be true
+    end
+
+    examplejsonpath2 = 'spec/octopus/serverspec/json/envnotfound.json'
+    examplejson2 = File.open(examplejsonpath2) # you get an IOError if you reuse the earlier File.open()
+
+    it "handles environment not found" do
+        stub_request(:get, "https://octopus2.example.com/api/environments?api-key=API-0987654321&name=Not-an-Env").
+            to_return(status: 200, body: examplejson2, headers: {})
+        enf = OctopusDeployEnvironment.new("https://octopus2.example.com", "API-0987654321", "Not-an-Env")
+        expect(enf.exists?).to be false
+    end
+
+    it "doesn't crash badly if handed a bad URL" do
+        stub_request(:get, "https://octopus.example.com/api/environments/all?api-key=API-1234567890&name=The-Env").to_raise(StandardError)
+
+        expect { OctopusDeployEnvironment.new("https://octopus.example.com", "API-1234567890", "The-Env") }.to raise_error
+    end
+
+end

--- a/spec/octopus/serverspec/type/octopus_deploy_environment_spec.rb
+++ b/spec/octopus/serverspec/type/octopus_deploy_environment_spec.rb
@@ -24,7 +24,7 @@ describe OctopusDeployEnvironment do
     examplejson = File.open(examplejsonpath)
 
     it "handles environment found" do
-        stub_request(:get, "https://octopus.example.com/api/environments?api-key=API-1234567890&name=The-Env").
+        stub_request(:get, "https://octopus.example.com/api/environments?name=The-Env&api-key=API-1234567890").
             to_return(status: 200, body: examplejson, headers: {})
         ef = OctopusDeployEnvironment.new("https://octopus.example.com", "API-1234567890", "The-Env")
         expect(ef.exists?).to be true
@@ -34,16 +34,16 @@ describe OctopusDeployEnvironment do
     examplejson2 = File.open(examplejsonpath2) # you get an IOError if you reuse the earlier File.open()
 
     it "handles environment not found" do
-        stub_request(:get, "https://octopus2.example.com/api/environments?api-key=API-0987654321&name=Not-an-Env").
+        stub_request(:get, "https://octopus2.example.com/api/environments?name=Not-an-Env&api-key=API-0987654321").
             to_return(status: 200, body: examplejson2, headers: {})
         enf = OctopusDeployEnvironment.new("https://octopus2.example.com", "API-0987654321", "Not-an-Env")
         expect(enf.exists?).to be false
     end
 
     it "doesn't crash badly if handed a bad URL" do
-        stub_request(:get, "https://octopus.example.com/api/environments/all?api-key=API-1234567890&name=The-Env").to_raise(StandardError)
+        stub_request(:get, "https://octopus.example.com/api/environments?name=The-Env&api-key=API-1234567890").to_raise(StandardError)
 
-        expect { OctopusDeployEnvironment.new("https://octopus.example.com", "API-1234567890", "The-Env") }.to raise_error
+        expect { OctopusDeployEnvironment.new("https://octopus.example.com", "API-1234567890", "The-Env") }.to raise_error(StandardError)
     end
 
 end

--- a/spec/octopus/serverspec/type/octopus_deploy_worker_pool_spec.rb
+++ b/spec/octopus/serverspec/type/octopus_deploy_worker_pool_spec.rb
@@ -42,7 +42,7 @@ describe OctopusDeployWorkerPool do
     it "doesn't crash badly if handed a bad URL" do
         stub_request(:get, "https://octopus.example.com/api/workerpools/all?api-key=API-1234567890").to_raise(StandardError)
 
-        expect { OctopusDeployWorkerPool.new("https://octopus.example.com", "API-1234567890", "Second Worker Pool") }.to raise_error
+        expect { OctopusDeployWorkerPool.new("https://octopus.example.com", "API-1234567890", "Second Worker Pool") }.to raise_error(StandardError)
     end
 
 end

--- a/spec/octopus/serverspec/type/octopus_deploy_worker_pool_spec.rb
+++ b/spec/octopus/serverspec/type/octopus_deploy_worker_pool_spec.rb
@@ -5,7 +5,6 @@ describe OctopusDeployWorkerPool do
 
     let(:runner) { double ("runner")}
 
-
     it "throws if `serverUrl` not supplied" do
         expect { OctopusDeployWorkerPool.new(nil, "someapikey", "my new worker pool") }.
             to raise_error(/serverUrl/)

--- a/spec/octopus/serverspec/type/octopus_deploy_worker_pool_spec.rb
+++ b/spec/octopus/serverspec/type/octopus_deploy_worker_pool_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'webmock/rspec'
+
+describe OctopusDeployWorkerPool do
+
+    let(:runner) { double ("runner")}
+
+
+    it "throws if `serverUrl` not supplied" do
+        expect { OctopusDeployWorkerPool.new(nil, "someapikey", "my new worker pool") }.
+            to raise_error(/serverUrl/)
+    end
+
+    it "throws if `apiKey` not supplied" do
+        expect { OctopusDeployWorkerPool.new("https://someserver.com", nil, "my new worker pool") }.
+            to raise_error(/apiKey/)
+    end
+
+    it "throws if `workerPoolName` not supplied" do
+        expect { OctopusDeployWorkerPool.new("https://someserver.com", "API-kllkjhasdkljhasdfkjsafd", nil) }.
+            to raise_error(/worker_pool_name/)
+    end
+
+    examplejsonpath = 'spec/octopus/serverspec/json/workerpoolsall.json'
+    examplejson = File.open(examplejsonpath)
+
+    it "handles worker pool found" do
+        stub_request(:get, "https://octopus.example.com/api/workerpools/all?api-key=API-1234567890").
+            to_return(status: 200, body: examplejson, headers: {})
+        wp = OctopusDeployWorkerPool.new("https://octopus.example.com", "API-1234567890", "Second Worker Pool")
+        expect(wp.exists?).to be true
+    end
+
+    examplejson2 = File.open(examplejsonpath) # you get an IOError if you reuse the earlier File.open()
+
+    it "handles worker pool not found" do
+        stub_request(:get, "https://octopus2.example.com/api/workerpools/all?api-key=API-0987654321").
+            to_return(status: 200, body: examplejson2, headers: {})
+        wp = OctopusDeployWorkerPool.new("https://octopus2.example.com", "API-0987654321", "Ninth Worker Pool")
+        expect(wp.exists?).to be false
+    end
+
+    it "doesn't crash badly if handed a bad URL" do
+        stub_request(:get, "https://octopus.example.com/api/workerpools/all?api-key=API-1234567890").to_raise(StandardError)
+
+        expect { OctopusDeployWorkerPool.new("https://octopus.example.com", "API-1234567890", "Second Worker Pool") }.to raise_error
+    end
+
+end

--- a/spec/octopus/serverspec/type/octopus_deploy_worker_pool_spec.rb
+++ b/spec/octopus/serverspec/type/octopus_deploy_worker_pool_spec.rb
@@ -20,29 +20,28 @@ describe OctopusDeployWorkerPool do
             to raise_error(/worker_pool_name/)
     end
 
-    examplejsonpath = 'spec/octopus/serverspec/json/workerpoolsall.json'
-    examplejson = File.open(examplejsonpath)
+    example_worker_pool_response = File.open('spec/octopus/serverspec/json/workerpoolsall.json')
 
     it "handles worker pool found" do
         stub_request(:get, "https://octopus.example.com/api/workerpools/all?api-key=API-1234567890").
-            to_return(status: 200, body: examplejson, headers: {})
+            to_return(status: 200, body: example_worker_pool_response, headers: {})
         wp = OctopusDeployWorkerPool.new("https://octopus.example.com", "API-1234567890", "Second Worker Pool")
         expect(wp.exists?).to be true
     end
 
-    examplejson2 = File.open(examplejsonpath) # you get an IOError if you reuse the earlier File.open()
+    example_worker_pool_response_2 = File.open('spec/octopus/serverspec/json/workerpoolsall.json') # you get an IOError if you reuse the earlier File.open()
 
     it "handles worker pool not found" do
         stub_request(:get, "https://octopus2.example.com/api/workerpools/all?api-key=API-0987654321").
-            to_return(status: 200, body: examplejson2, headers: {})
+            to_return(status: 200, body: example_worker_pool_response_2, headers: {})
         wp = OctopusDeployWorkerPool.new("https://octopus2.example.com", "API-0987654321", "Ninth Worker Pool")
         expect(wp.exists?).to be false
     end
 
     it "doesn't crash badly if handed a bad URL" do
-        stub_request(:get, "https://octopus.example.com/api/workerpools/all?api-key=API-1234567890").to_raise(StandardError)
+        stub_request(:get, "https://nonexistentdomain.com/api/workerpools/all?api-key=API-1234567890").to_raise(SocketError)
 
-        expect { OctopusDeployWorkerPool.new("https://octopus.example.com", "API-1234567890", "Second Worker Pool") }.to raise_error(StandardError)
+        expect { OctopusDeployWorkerPool.new("https://nonexistentdomain.com", "API-1234567890", "Second Worker Pool") }.to raise_error(StandardError)
     end
 
 end


### PR DESCRIPTION
A couple of these tests feel a little circular, but they work.

- Worker Pools and Environments now have basic tests
- Tweaked several `.nil?` behaviours as a result of putting the tests in place. 
- Now raising exceptions instead of empty `return`s. 
- Previously, an empty array returned from the API would appear like an environment or worker pool existed, when in fact it didn't.