### PR TITLE
Add the ability to check the TenantedDeploymentParticipation property

### DIFF
--- a/lib/octopus_serverspec_extensions/type/octopus_deploy_tentacle.rb
+++ b/lib/octopus_serverspec_extensions/type/octopus_deploy_tentacle.rb
@@ -125,6 +125,11 @@ module Serverspec::Type
       @machine["Uri"].casecmp(uri) == 0
     end
 
+    def has_tenanted_deployment_participation?(mode)
+      return false if @machine.nil?
+      @machine["TenantedDeploymentParticipation"] == mode
+    end
+
     def listening_tentacle?
       return false if @machine.nil?
       puts "Expected CommunicationStyle 'TentaclePassive' for Tentacle #{@name}, but got '#{@machine["Endpoint"]["CommunicationStyle"]}'" if (@machine["Endpoint"]["CommunicationStyle"] != "TentaclePassive")


### PR DESCRIPTION
Does what it says on the tin, to support a change for https://github.com/OctopusDeploy/OctopusDSC/issues/190

There aren't any tests for the tentacle type. Probably something we should look into.